### PR TITLE
Resend userAgent from js context

### DIFF
--- a/lib/rabbitmq/RabbitMqTransport.js
+++ b/lib/rabbitmq/RabbitMqTransport.js
@@ -183,6 +183,7 @@ class RabbitMqTransport {
         'correlation-id': corrId,
         'retry-max-attempts': context.maxRetries ? context.maxRetries : (hasResponse ? 0 : this.defaultCommandRetries), // commands retriable by default
         'expired-at': context.timeout ? Date.now() + context.timeout : null,
+        'userAgent': context.Headers.userAgent,
         timestamp: Date.now(),
       },
     };


### PR DESCRIPTION
a useful resolution and generalization with com.sbuslab.sbus.rabbitmq.RabbitMqTransport, where we can resend  the same header parameter